### PR TITLE
Allow param props to be reassigned and test.

### DIFF
--- a/linters/.eslintrc
+++ b/linters/.eslintrc
@@ -101,7 +101,7 @@
     # FUNCTIONS <https://github.com/thenerdery/javascript-standards#functions>
     ###############################################################################################
 
-    "no-param-reassign": [2, {"props": true}],    # Disallow reassignment of parameters
+    "no-param-reassign": [2, {"props": false}],    # Disallow reassignment of parameters
     "max-params": [2, 5],                         # Disallow more than 5 parameters
     "prefer-rest-params": 2,                      # Require rest parameters instead of `arguments`
     "wrap-iife": [2, "outside"],                  # Require IIFEs to be wrapped

--- a/linters/tests/functions.js
+++ b/linters/tests/functions.js
@@ -28,6 +28,13 @@
     }
 }());
 
+(function() {
+    // good
+    function foo(a) {
+        a.b = 1;
+    }
+}());
+
 // https://github.com/thenerdery/javascript-standards#functions--default-parameters
 // eslint: no-param-reassign
 (function() {


### PR DESCRIPTION
I think we should allow parameter properties to be reassigned.  Not doing so prevents us from doing something like:

```
const elements = document.querySelectorAll('.selector');
elements.forEach(el => { el.style.display = 'block'; });
```
